### PR TITLE
addition of margin-top in whoisNH section

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,7 +169,7 @@
               can access my GitHub profile on the "connect" page.
             </p>
           </div>
-          <img
+          <img style="margin-top:20px;"
             src="https://cdn.nhcarrigan.com/profile.png"
             width="250px"
           />


### PR DESCRIPTION
## Description

Adding a margin-top above the avatar in whoisNH section.

## Related Issue

Missing Photo of Timiro and RavenclawFander